### PR TITLE
Use head instead of cat because otherwise it's stuck indefinitely

### DIFF
--- a/factorio
+++ b/factorio
@@ -298,7 +298,7 @@ send_cmd(){
   if is_running; then
     if [ -p ${FIFO} ]; then
       # Grab a random 16 character id for our command
-      cmdid=$(cat /dev/urandom |tr -dc 'a-zA-Z0-9' |fold -w 16 |head -n 1)
+      cmdid=$(head -c 1000 /dev/urandom |tr -dc 'a-zA-Z0-9' |fold -w 16 |head -n 1)
       # Whisper that unknown player named after our random id
       echo "/w ${cmdid}" > ${FIFO}
       # Wait for factorio to read stdin


### PR DESCRIPTION
@maikelwever can you double-check please, but this should work fine. My issue is that cat was being stuck indefinitely reading from urandom when command was run via php script at random times - mostly it worked fine, but sometimes it didn't.

Also, why do you need this hack with random player name at all?