### PR TITLE
Automatic builds and releases with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Apt update
+      run: sudo apt update
+      
+    - name: Install dependencies
+      run: sudo apt install devscripts dpkg-dev debhelper debianutils bash-completion -y
+      
+    - name: Build
+      run: debuild -us -uc # Build unsigned
+      
+    - name: Create output folder
+      run: mkdir build
+
+    - name: Move build result
+      run: cp ../*.deb ./build
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        # Artifact name
+        name: factorio-multienv-ctl-debian # optional, default is artifact
+        path: build
+        if-no-files-found: error # optional, default is warn
+        # Duration after which artifact will expire in days. 0 means using default retention.
+        # Minimum 1 day. Maximum 90 days unless changed from the repository settings page.
+        retention-days: 0 # optional
+
+  pre-release:
+    needs: build
+    name: "Pre Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@master
+        with:
+          name: factorio-multienv-ctl-debian
+          path: .
+      
+      - name: List files
+        run: ls
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            *.deb

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 debian/factorio-init/*
 *.debhelper.log
 .idea
+debian/factorio-multienv-ctl*
+debian/.debhelper
+debian/files

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+factorio-multienv-ctl (1.0.0) unstable; urgency=medium
+
+  * New build system, now always builds latest factorio version
+
+ -- DESKTOP-1600X <danielv@DESKTOP-1600X.localdomain>  Sat, 16 Oct 2021 17:59:38 +0200
+
 factorio-multienv-ctl (0.17.74) stable; urgency=medium
 
   * Update to 0.17.74

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,7 +4,7 @@
 set -e
 
 PKG=factorio-mutlienv-ctl
-SERVER_VERSION="0.17.74"
+SERVER_VERSION="latest" # For earlier versions this was set to the current factorio version, ex 0.17.74.
 SERVER_DL_URL="https://www.factorio.com/get-download/$SERVER_VERSION/headless/linux64"
 INSTALL_DIR="/opt/factorio"
 TAR_DIR_NAME="factorio"


### PR DESCRIPTION
resolves #21 

Currently it uploads the artifact to a prerelease which can be manually promoted to a proper release once tested.